### PR TITLE
Set the size of the preallocated output buffer

### DIFF
--- a/Bond.PerformanceTest/Program.cs
+++ b/Bond.PerformanceTest/Program.cs
@@ -34,7 +34,7 @@ namespace Bond.PerformanceTest
             {
                 var p = CreateBondPerson();
 
-                var output = new OutputBuffer();
+                var output = new OutputBuffer(256);
                 var writer = new CompactBinaryWriter<OutputBuffer>(output);
                 serializer.Serialize(p, writer);
             };
@@ -75,7 +75,7 @@ namespace Bond.PerformanceTest
             {
                 var person = CreateBondPerson();
 
-                var output = new OutputBuffer();
+                var output = new OutputBuffer(256);
                 var writer = new FastBinaryWriter<OutputBuffer>(output);
                 serializer.Serialize(person, writer);
             };


### PR DESCRIPTION
Output buffer by default preallocates 64KB of memory. When serializing
very small objects like Person in this test this is unnecessary and
costly (.NET will zero out allocated memory). Specifying the output size
to be more appropriate for the size of the data shows the actual cost of
serialization rather than redundant memset. In our tests Bond is faster
then protobuf.net for both serialization and deserialization.
